### PR TITLE
Adding support to handle (ignore) subdomains in RDAP scans

### DIFF
--- a/src/utils/scanners/rdapScanner.ts
+++ b/src/utils/scanners/rdapScanner.ts
@@ -25,6 +25,8 @@ export const rdapScanner: DomainScanner = {
           summary: i18next.t('rdap.summary.invalid', { ns: 'scanners' }),
           issues: [i18next.t('rdap.issues.invalidDomain', { ns: 'scanners' })]
         };
+      } else if (parts.length > 2) {
+        domain = parts.slice(-2).join(".");
       }
 
       const tld = parts[parts.length - 1];

--- a/src/utils/scanners/rdapScanner.ts
+++ b/src/utils/scanners/rdapScanner.ts
@@ -25,6 +25,8 @@ export const rdapScanner: DomainScanner = {
           summary: i18next.t('rdap.summary.invalid', { ns: 'scanners' }),
           issues: [i18next.t('rdap.issues.invalidDomain', { ns: 'scanners' })]
         };
+      } else if (parts.length > 2) {
+        domain = parts.slice(-2).join('.');
       }
 
       const tld = parts[parts.length - 1];


### PR DESCRIPTION
Closing #66 - "For the RDAP scan, only look at the second-level and top-level domains (e.g.: blacksmithinfosec.com) instead of including the subdomain (e.g.: assess.blacksmithinfosec.com). Otherwise, the RDAP server may not find results for the domain."
